### PR TITLE
Fix CSP buffer/distance calculations in put screening

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,8 +54,10 @@ def get_puts(ticker_obj, stock, stockprice, min_days, max_days, min_cagr, max_ca
             puts['CAGR'] = puts.apply(lambda row: calc_put_cagr(row['lastPrice'], row['strike'], row['dte']), axis=1)
             puts['P/L'] = puts.apply(lambda row: calc_put_pnl(row['lastPrice'], row['strike']), axis=1)
             puts['Moneyness'] = puts.apply(lambda row: round((row['strike'] / stockprice), 2), axis=1)
-            puts['Puffer'] = puts.apply(lambda row: row['strike'] - row['lastPrice'], axis=1)
-            puts['Abstand%'] = puts.apply(lambda row: ((stockprice / row['Puffer']) - 1) * 100, axis=1)
+            # "Puffer" is the price distance between current stock price and strike.
+            # Using option premium (lastPrice) here was incorrect and produced distorted values.
+            puts['Puffer'] = puts.apply(lambda row: stockprice - row['strike'], axis=1)
+            puts['Abstand%'] = puts.apply(lambda row: (row['Puffer'] / stockprice) * 100, axis=1)
             puts['Faktor'] = puts.apply(lambda row: ((row['Abstand%'] / 100) * row['CAGR']), axis=1)
             
             # alle Put-Expirations zusammenfügen


### PR DESCRIPTION
### Motivation
- The put screening logic computed `Puffer` using the option premium and applied an incorrect percent formula for `Abstand%`, which produced distorted distance metrics for cash-secured put evaluation.

### Description
- In `get_puts` (`app.py`) `Puffer` is now calculated as `stockprice - strike` and `Abstand%` as `(Puffer / stockprice) * 100`, with a clarifying comment added to explain the change.

### Testing
- Ran `python -m py_compile app.py` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69936ae76d3c83268c7dfada346a0299)