### PR TITLE
Harden CSP filtering logic and fix yfinance requirement

### DIFF
--- a/app.py
+++ b/app.py
@@ -63,8 +63,40 @@ def get_puts(ticker_obj, stock, stockprice, min_days, max_days, min_cagr, max_ca
             # alle Put-Expirations zusammenfügen
             putlist = pd.concat([putlist, puts], ignore_index=True)
     
+    if putlist.empty:
+        return pd.DataFrame(
+            columns=[
+                'Symbol',
+                'lastPrice',
+                'strike',
+                'expiration',
+                'dte',
+                'Moneyness',
+                'Faktor',
+                'CAGR',
+                'P/L',
+                'delta',
+            ]
+        )
+
     # Nach Voragbe CAGR filtern
     filtered_puts = putlist[(putlist['CAGR'] >= min_cagr) & (putlist['CAGR'] <= max_cagr)]
+
+    if filtered_puts.empty:
+        return pd.DataFrame(
+            columns=[
+                'Symbol',
+                'lastPrice',
+                'strike',
+                'expiration',
+                'dte',
+                'Moneyness',
+                'Faktor',
+                'CAGR',
+                'P/L',
+                'delta',
+            ]
+        )
     
     # Delta berechnen (hier beispielhaft als Dummy-Wert, da yFinance das Delta nicht direkt liefert)
     filtered_puts['delta'] = filtered_puts.apply(lambda x: get_greeks('p', stockprice, x['strike'], x['dte'], 0.0455, x['lastPrice']).putDelta, axis=1)
@@ -84,6 +116,8 @@ def calc_put_cagr(p, s, dte):
     # p: Put Preis
     # s: Strike
     # dte: Days To Expiration
+    if dte <= 0:
+        return 0
     cagr = (p / s) * (365 / dte) * 100
     return cagr
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,4 +51,4 @@ tzdata==2024.1
 urllib3==2.2.1
 watchdog==4.0.0
 webencodings==0.5.1
-yfinance=>0.2.38
+yfinance>=0.2.38


### PR DESCRIPTION
### Motivation

- Fix a malformed dependency specifier that prevented `pip` from parsing `requirements.txt` and improve runtime robustness when option data is missing. 
- Prevent runtime crashes from divide-by-zero when calculating CAGR for zero/negative DTE values. 

### Description

- Corrected the `yfinance` specifier in `requirements.txt` from `=>0.2.38` to `>=0.2.38` so `pip` can parse the file. 
- Made `get_puts()` return an empty but schema-consistent `DataFrame` when no option chains match the requested expiry range. 
- Added an early return of an empty schema-consistent `DataFrame` when the CAGR-filtered result is empty. 
- Guarded `calc_put_cagr()` with `if dte <= 0: return 0` to avoid division-by-zero. 

### Testing

- Ran `python -m py_compile app.py` and it passed without syntax errors. 
- Ran `python -m pip install -r requirements.txt` which now passes the earlier parsing error but fails to fetch packages due to an environment proxy resulting in `403 Forbidden` when contacting the package index (network/proxy issue, not a code problem).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69936c760bb4832695caf20082a8ca02)